### PR TITLE
[codex] refresh README for setup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,69 @@
-# Markdown Guides and Scripts
+# Linux Setup Scripts and Notes
 
-Linux-first setup notes and helper scripts for CUDA, Docker + NVIDIA runtime, GPG signing, and Git LFS.
+Helper scripts and docs for Ubuntu-based GPU workstation setup: CUDA 12.4, Docker with NVIDIA runtime, GPG commit signing, and Git LFS.
 
 ## Quick Start
 
 ### Prerequisites
-- Ubuntu 22.04 (or compatible Debian-based distro for the CUDA scripts)
-- NVIDIA GPU + driver
-- `bash`, `gpg`, `git`, and `sudo` access
+- Ubuntu 22.04 (or compatible Debian-based distro)
+- NVIDIA GPU with working driver (`nvidia-smi`)
+- `bash`, `git`, `gpg`, `curl`, and `sudo` access
 
-### Setup
+### Clone and prepare
 ```bash
 git clone <your-repo-url>
 cd markdown
 chmod +x scripts/*.sh
 ```
 
-### Run
+### Fast path
 ```bash
-# 1) Configure GPG key template (edit name/email first)
+# 1) Customize key identity fields first, then generate a GPG key
 gpg --batch --generate-key scripts/gpg-key.sh
 
-# 2) CUDA and Docker runtime install (interactive + reboot required)
+# 2) Install CUDA + Docker + NVIDIA container runtime (interactive)
 bash scripts/cuda_install_part1.sh
+
+# 3) Apply CUDA PATH/LD_LIBRARY_PATH updates
 bash scripts/cuda_install_part2.sh
 ```
 
-## Features
-- GPG key template for commit-signing setup.
-- Two-part CUDA + Docker/NVIDIA container runtime install flow.
-- Ready-to-scan docs for Git LFS, Docker commands, and NVIDIA toolkit setup.
+## Core Capabilities
+- `scripts/cuda_install_part1.sh`: reinstalls CUDA stack and configures Docker + NVIDIA runtime.
+- `scripts/cuda_install_part2.sh`: appends CUDA environment variables to `~/.bashrc`.
+- `scripts/gpg-key.sh`: batch template for generating a 4096-bit RSA OpenPGP key.
+- `docs/`: focused how-tos for Git LFS, Docker commands, NVIDIA toolkit, and GPG setup.
 
 ## Configuration
-- `scripts/gpg-key.sh`: set `Name-Real`, `Name-Email`, and optional `Name-Comment` before key generation.
+- Edit `scripts/gpg-key.sh` before running:
+  - `Name-Real`
+  - `Name-Email`
+  - `Name-Comment` (optional)
 
 ## Usage
 ```bash
-# Verify GPU and CUDA toolchain after setup
+# Validate CUDA and GPU visibility
 nvidia-smi
 nvcc --version
 
-# Verify Docker can access GPU
-sudo docker run --rm --gpus all nvidia/cuda:11.0-base nvidia-smi
+# Validate Docker GPU access
+docker run --rm --gpus all nvidia/cuda:11.0-base nvidia-smi
 ```
-
-Docs for each workflow are in:
-- `docs/gpg-key-instructions.md`
-- `docs/install-git-LFS.md`
-- `docs/useful-docker-commands.md`
-- `docs/nvidia-container-toolkit-install.md`
 
 ## Contributing and Testing
 ```bash
-# Check shell syntax quickly
 bash -n scripts/gpg-key.sh
 bash -n scripts/cuda_install_part1.sh
 bash -n scripts/cuda_install_part2.sh
 ```
 
-Open a PR with any fixes to scripts or docs and include the distro/GPU tested.
+Open a PR with the distro/GPU you validated on.
+
+## Docs
+- `docs/gpg-key-instructions.md`
+- `docs/install-git-LFS.md`
+- `docs/nvidia-container-toolkit-install.md`
+- `docs/useful-docker-commands.md`
 
 ## License
 Licensed under the `MIT` license. See [LICENSE](./LICENSE) for full text.


### PR DESCRIPTION
## Issue
The repository includes useful CUDA/Docker/GPG helper scripts, but the README was verbose and less structured for first-time use. It mixed setup detail and reference material in a way that made the fastest execution path harder to scan.

## Cause and User Impact
The previous README had content overlap with the `docs/` folder and buried key steps (what to edit, what to run, and what to validate). New users could still run the project, but they needed more time to identify required prerequisites and command order.

## Root Cause
Documentation drift: operational docs expanded over time while the top-level README did not stay tightly scoped as an entrypoint.

## Fix
- Reworked `README.md` into a small-project format focused on first-run clarity.
- Kept a direct quick-start flow with prerequisite checks and command sequence.
- Clarified script responsibilities (`cuda_install_part1.sh`, `cuda_install_part2.sh`, `gpg-key.sh`).
- Kept configuration explicit for required editable values in `scripts/gpg-key.sh`.
- Preserved SPDX-style license section and linked supporting docs instead of duplicating details.

## Validation
- Ran shell syntax checks for all scripts:
  - `bash -n scripts/gpg-key.sh`
  - `bash -n scripts/cuda_install_part1.sh`
  - `bash -n scripts/cuda_install_part2.sh`
- Confirmed only README content changed.
